### PR TITLE
Prevent redirect away from wp-login.php when logging out

### DIFF
--- a/classes/brutus.php
+++ b/classes/brutus.php
@@ -97,7 +97,9 @@ final class Brutus {
 	 * @since Brutus (1.0.0)
 	 */
 	public function login_init() {
-		self::verify_nonce();
+		if ( ! did_action('wp_logout') ) {
+			self::verify_nonce();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Simply by checking whether or not the action "wp_logout" was fired prior to verifying the nonce will prevent the user from being redirected to the result of network_home_url() when logging out.

This PR is in relation to one of the adverse effects listed on the main repository page:

> When a user signs out, they are redirected back to the root of the site rather than wp-login.php. This is because the nonce used by the previously signed-in user does not match the nonce of the now signed-out user, Brutus (correctly) detects a mismatch, and bounces the user away from wp-login.php. This could be improved, but I haven't spent enough time trying to unwind the redirection dance here.
